### PR TITLE
Local Firmware

### DIFF
--- a/catnip_uploader/catnip_uploader.py
+++ b/catnip_uploader/catnip_uploader.py
@@ -1,12 +1,12 @@
 # Catnip Uploader is a Python script that allows you to upload firmware to CatSniffer boards V3.
 # This file is part of the CatSniffer project, http://electroniccats.com/
 # GNU GENERAL PUBLIC LICENSE
-# Version 3, 29 June 2007
+# Version 1 2024
+# Kevin Leon <@kevlem97>
 
 # Copyright (C) 2007 Free Software Foundation, Inc. https://fsf.org/
 # Everyone is permitted to copy and distribute verbatim copies
 # of this license document, but changing it is not allowed.
-
 
 import typer
 import serial
@@ -62,8 +62,9 @@ def validate_python_call():
     return "python"
 
 def validate_firmware_selected(firmware_selected: int):
-    get_release = release_handler.get_release()
-    LOG_INFO(f"Validating selected firmware: {firmware_selected}")
+    get_release = release_handler.get_local_releases_dict()
+    #get_release = release_handler.get_release()
+    LOG_INFO(f"Validating selected firmware: {firmware_selected} - {get_release[firmware_selected]}")
     if firmware_selected not in get_release:
         LOG_ERROR(f"Selected firmware invalid: {firmware_selected}")
         sys.exit(1)
@@ -73,59 +74,158 @@ class Release:
     def __init__(self):
         self.release_data = None
         self.temp_filename = "releases.json"
+        self.tag_version = None 
         self.release_json = self.__fetch_release()
-
+    
     def __fetch_assets(self):
-        request_release = requests.get(f"{GITHUB_RELEASE_URL}")
-        request_release.raise_for_status()
-        req_release_data = request_release.json()
-        LOG_INFO(f"Fetching assets from {GITHUB_RELEASE_URL}")
-        LOG_INFO(f"Release: {req_release_data['tag_name']}")
-        return req_release_data["assets"]
+        """Fetch the assets from the release."""
+        try:
+            request_release = requests.get(f"{GITHUB_RELEASE_URL}")
+            request_release.raise_for_status()
+
+            if request_release.status_code != 200:
+                LOG_ERROR(f"Error fetching assets: {request_release.status_code}")
+                sys.exit(1)
+
+            req_release_data = request_release.json()
+            LOG_INFO(f"Fetching assets from {GITHUB_RELEASE_URL}")
+            LOG_INFO(f"Release: {req_release_data['tag_name']}")
+
+            self.tag_version = req_release_data['tag_name']
+
+            return req_release_data["assets"]
+        except requests.exceptions.ConnectionError as e:
+            has_local_release = self.find_folder_releases()
+            if has_local_release is not None:
+                return None
+            LOG_ERROR("Error. You need internet connection for the first use to download the firmware")
+            sys.exit(1)
+        except Exception as e:
+            LOG_ERROR(f"Error fetching assets: {e}")
+            sys.exit(1)
+
 
     def __fetch_release(self):
-        repo_assets = self.__fetch_assets()
-        
-        for asset in repo_assets:
-            if asset["name"] == RELEASE_JSON_FILENAME:
-                req_release_data = asset["browser_download_url"]
-                request_release = requests.get(req_release_data)
-                content = request_release.content
-                content_bytes = io.BytesIO(content)
-                
-                self.write_json_file(self.temp_filename, content_bytes.read().decode())
-                self.release_data = self.read_json_file(self.temp_filename)
-                
-        json_release = json.loads(self.release_data)["board_v3"]
-        return self.__create_dict_release(json_release)
+        """Fetch the release data from the repo."""
+        try:
+            firmware_releases = []
+            repo_assets = self.__fetch_assets()
+            if repo_assets is None:
+                return self.get_local_releases_dict()
+            # Check if the lasted release is already downloaded
+            has_local_release = self.find_folder_releases()
+            if has_local_release is not None:
+                # The local release is found
+                LOG_INFO(f"Found local release: {has_local_release}")
+                has_lasted_release = self.has_lasted_release(self.tag_version)
+                if has_lasted_release:
+                    LOG_SUCCESS(f"Local release is up to date: {self.tag_version}")
+                    firmware_releases = self.get_local_releases_dict()
+                    return firmware_releases
+                else:
+                    LOG_WARNING(f"Updating local release: {has_local_release} to {self.tag_version}")
+
+            LOG_INFO("Fetching release data")
+
+            self.create_release_folder(self.tag_version)
+            
+
+            for asset in repo_assets:
+                if asset["name"] == RELEASE_JSON_FILENAME:
+                    req_release_data = asset["browser_download_url"]
+                    request_release = requests.get(req_release_data)
+                    content = request_release.content
+                    content_bytes = io.BytesIO(content)
+                    
+                    self.write_json_file(self.temp_filename, content_bytes.read().decode())
+                    self.release_data = self.read_json_file(self.temp_filename)
+                else:
+                    # To avoid the uf3 files until we have a way to upload them
+                    if asset["name"].endswith(".hex"):
+                        with open(os.path.join(f"releases_{self.tag_version}", asset["name"]), "wb") as f:
+                            request_release = requests.get(asset["browser_download_url"])
+                            content_bytes = io.BytesIO(request_release.content)
+                            f.write(content_bytes.read())
+                            firmware_releases.append(asset["name"])
+            return self.__create_dict_release(firmware_releases)
+        except Exception as e:
+            LOG_ERROR(f"Error with the repo assets. Please check the current version of the script and the release: {e}")
+            sys.exit(1)
 
     def __create_dict_release(self, release_data: dict = None):
+        """Create a dictionary with the release data."""
         release_dict = {}
         for index, release in enumerate(release_data):
             release_dict[index] = release
         return release_dict
 
     def get_release(self):
+        """Return the release data. If it's not available, return the local release data."""
+        if self.release_json is None:
+            self.release_json = self.get_local_releases_dict()
         return self.release_json
     
     def read_json_file(self, filename: str):
         with open(filename, "r") as f:
             return json.load(f)
     
-    def write_json_file(self, filename: str, data):
+    def write_json_file(self, filename: str, data) -> None:
         with open(filename, "w") as f:
             f.write(json.dumps(data))
     
-    def download_firmware(self, firmware_selected: int):
-        repo_assets = self.__fetch_assets()
-        print(self.release_json[int(firmware_selected)])
-        for asset in repo_assets:
-            if asset["name"] == self.release_json[firmware_selected]:
-                req_release_data = asset["browser_download_url"]
-                request_release = requests.get(req_release_data)
-                content = request_release.content
-                return content
+    def remove_local_files_releases(self, release_folder: str) -> None:
+        """Clean up the local releases folder."""
+        list_files = os.listdir(release_folder)
+        for file in list_files:
+            os.remove(os.path.join(release_folder, file)) 
+
+    def has_lasted_release(self, lasted_release) -> bool:
+        """Check if the lasted release is already downloaded."""
+        dir_files = os.listdir(os.getcwd())
+        for dir_name in dir_files:
+            if dir_name.startswith("releases_"):
+                if dir_name.replace("releases_", "") == lasted_release:
+                    return True
+        return False
+
+    def get_local_releases_dict(self) -> dict:
+        """Get the local releases."""
+        release_folder = self.find_folder_releases()
+        if release_folder is not None:
+            list_files = os.listdir(release_folder)
+            return self.__create_dict_release(list_files)
+        return {}
+
+    def find_folder_releases(self) -> str:
+        """Find the releases folder."""
+        dir_files = os.listdir(os.getcwd())
+        for dir_name in dir_files:
+            if dir_name.startswith("releases_"):
+                return dir_name
         return None
+
+    def create_release_folder(self, tag_version):
+        """Create the release folder."""
+        if tag_version is None:
+            return
+        exist_prev_release = self.find_folder_releases()
+        if exist_prev_release is None:
+            if not os.path.exists(f"releases_{tag_version}"):
+                os.mkdir(f"releases_{tag_version}")
+        else:
+            LOG_WARNING(f"Previous release found: {exist_prev_release} updating to {tag_version}")
+            self.remove_local_files_releases(exist_prev_release)
+            os.rename(exist_prev_release, f"releases_{tag_version}")
+            
+    def get_firmware_releases(self, firmware_selected: int):
+        """Get the firmware releases."""
+        releases_firmware = self.get_local_releases_dict()
+        print(releases_firmware[firmware_selected])
+        if releases_firmware is None:
+            LOG_ERROR(f"Error with the releases folder")
+            return None
+        
+        return os.path.join(self.find_folder_releases(), releases_firmware[firmware_selected])
 
 
 class BoardUart:
@@ -134,7 +234,7 @@ class BoardUart:
         self.serial_worker.port     = serial_port
         self.serial_worker.baudrate = 921600
         self.firmware_selected      = 0
-        self.command_to_send        = f"cc2538.py -e -w -v -p {self.serial_worker.port} {TMP_FILE}"
+        self.command_to_send        = f"cc2538.py -e -w -v -p {self.serial_worker.port}"
         self.python_command         = validate_python_call()
     
     def validate_connection(self):
@@ -159,26 +259,20 @@ class BoardUart:
         self.serial_worker.close()
     
     def send_firmware(self):
-        LOG_INFO(f"Downloading {self.firmware_selected} - {release_handler.get_release()[self.firmware_selected]}")
-        firmware = release_handler.download_firmware(self.firmware_selected)
-        if firmware is None:
-            LOG_ERROR(f"Error downloading firmware: {self.firmware_selected}")
+        LOG_INFO(f"Getting {self.firmware_selected} - {release_handler.get_release()[self.firmware_selected]}")
+        firmware_bytes = release_handler.get_firmware_releases(self.firmware_selected)
+        if firmware_bytes is None:
+            LOG_ERROR(f"Error reading firmware: {self.firmware_selected}")
             sys.exit(1)
-        
-        LOG_SUCCESS(f"Downloaded {self.firmware_selected}")
-        
-        content_bytes = io.BytesIO(firmware)
-        self.create_tmp_file(content_bytes.read().decode())
         
         LOG_INFO(f"Uploading {release_handler.get_release()[self.firmware_selected]} to {self.serial_worker.port}")
         
         self.send_connect_boot()
         time.sleep(1)
         #TODO: Add a check to see if the command was successful
-        os.system(f"{self.python_command} {self.command_to_send}")
+        os.system(f"{self.python_command} {self.command_to_send} {firmware_bytes}")
         time.sleep(1)
         self.send_disconnect_boot()
-        self.remove_tmp_file()
         LOG_SUCCESS(f"Done uploading {self.firmware_selected} to {self.serial_worker.port}")
     
     def create_tmp_file(self, content_bytes):
@@ -201,7 +295,7 @@ app = typer.Typer(
 @app.command("releases")
 def list_releases():
     """List all available releases"""
-    typer.echo("Available releases:")
+    LOG_SUCCESS("Available releases:")
     get_release = release_handler.get_release()
     for release in get_release:
         typer.echo(f"{release}: {get_release[release]}")


### PR DESCRIPTION
- Validate the lasted release with the local
- Update the local firmware if this has a old version
- Load the firmware from local
- Online/Offline functionality

This tool now loads the firmware from local files to avoid internet connection issues. When you run it, the tool fetches the latest release version. If this fails, it falls back to using the local files. If you have an internet connection, it compares the local version with the tag version of the repository. If they are different, it updates the files.