### PR TITLE
Update catnip_uploader.py

### DIFF
--- a/catnip_uploader/catnip_uploader.py
+++ b/catnip_uploader/catnip_uploader.py
@@ -101,6 +101,9 @@ class Release:
             LOG_ERROR("Error. You need internet connection for the first use to download the firmware")
             sys.exit(1)
         except Exception as e:
+            has_local_release = self.find_folder_releases()
+            if has_local_release is not None:
+                return None
             LOG_ERROR(f"Error fetching assets: {e}")
             sys.exit(1)
 


### PR DESCRIPTION
Fixes bug:

[ERROR] Error fetching assets: 403 Client Error: rate limit exceeded for url: https://api.github.com/repos/ElectronicCats/CatSniffer-Firmware/releases/latest