### PR TITLE
feat: Add protocol filters

### DIFF
--- a/cativity/changelog.md
+++ b/cativity/changelog.md
@@ -1,0 +1,8 @@
+# Change Log
+## V1.1 - Cativity
+### Added
+- Protocol filter for Zigbee, Thread and All
+- Setup.py for pip installations
+### Fix
+- Fix character error
+- Fix Typos

--- a/cativity/modules/network.py
+++ b/cativity/modules/network.py
@@ -32,6 +32,18 @@ class Network:
         self.nStats = NetworkStats()
         self.grapher = Graphs()
 
+    def get_packet_filtered(self, packet, pfilter):
+        pkt = Dot15d4(packet)
+        if pfilter == "all":
+            return packet
+        elif pfilter == "thread":
+            if not pkt.haslayer(ZigbeeNWK) or not pkt.haslayer(ZigBeeBeacon):
+                return packet
+        else:
+            if pkt.haslayer(ZigbeeNWK) or pkt.haslayer(ZigBeeBeacon):
+                return packet
+        return None
+
     def dissect_packet(self, packet):
         pkt = Dot15d4(packet)
         new_pkt = {}

--- a/cativity/setup.py
+++ b/cativity/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="cativity",
+    version="1.1",
+    description="Cativity: A tool for channel activity",
+    author="Astrobyte",
+    url="https://github.com/ElectronicCats/CatSniffer-Tools",
+    packages=find_packages(include=["modules", "modules.*"]),
+    py_modules=["cativity"],
+    entry_points={
+        "console_scripts": [
+            "cativity=cativity:main",
+        ],
+    },
+    install_requires=[
+        "click",
+        "pyserial",
+        "typer",
+        "scapy",
+        "shellingham"
+    ],
+    include_package_data=True,
+    package_data={"modules": ["*.py"]},
+)


### PR DESCRIPTION
Hi!
I was working with a new thread device that I bought and this script works fine with that but you can't follow the activity in specific protocol, so I added a filters to do that, and fix some things, too I saw that added a setup.py for catnip and pycatsniffer so I added too.
I don't know if this applied for the reward or not but I havetwo main emails if you want to contact me:
astrobyte_sat@proton.me and dalet.gonzalez.m@outlook.com 
 If I had another update I will send the PR.
Regards. 

# Change Log
## V1.1 - Cativity
### Added
- Protocol filter for Zigbee, Thread and All
- Setup.py for pip installations
### Fix
- Fix character error
- Fix Typos