### PR TITLE
fix(flasher): stabilize CC1352 bootloader handoff before flashing

### DIFF
--- a/catnip/modules/flasher.py
+++ b/catnip/modules/flasher.py
@@ -89,12 +89,12 @@ class CCLoader:
         self.cmd.open(self.bridge_port, cat_baud)
 
     def enter_bootloader(self):
-        """Send boot command via shell port to enter CC1352 bootloader mode."""
+        """Force passthrough, then send boot command via shell port to enter CC1352 bootloader mode."""
         if self.shell_port:
             console.print(f"[*] Sending boot command via shell port: {self.shell_port}")
             self.shell = ShellConnection(port=self.shell_port)
             if self.shell.connect():
-                # Flush serial buffers before sending command
+                # Flush serial buffers before sending commands
                 if (
                     self.shell
                     and hasattr(self.shell, "connection")
@@ -105,12 +105,27 @@ class CCLoader:
                     if hasattr(self.shell.connection, "reset_output_buffer"):
                         self.shell.connection.reset_output_buffer()
 
+                # Some workflows leave the RP2040 bridge in a non-passthrough mode.
+                # Force a known-good state before requesting the CC1352 ROM bootloader.
+                try:
+                    self.shell.exit_bootloader()
+                    time.sleep(0.2)
+                except Exception:
+                    pass
+
                 result = self.shell.enter_bootloader()
                 time.sleep(0.2)
                 if result:
                     console.print("[*] Boot command sent successfully")
                 else:
                     console.print("[yellow][!] Boot command may have failed[/yellow]")
+
+                # Drop the shell connection before the bridge/UART mode switches fully.
+                try:
+                    self.shell.disconnect()
+                except Exception:
+                    pass
+                self.shell = None
             else:
                 console.print(f"[yellow][!] Could not connect to shell port[/yellow]")
         else:
@@ -764,8 +779,9 @@ class Flasher:
 
         Workflow:
         1. Send 'boot' command via Shell port → CC1352 enters bootloader
-        2. Flash firmware via Bridge port using cc2538 bootloader protocol
-        3. Send 'exit' command via Shell port → CC1352 exits bootloader
+        2. Wait briefly for the RP2040 bridge/UART mode switch to settle
+        3. Open the Bridge port at bootloader baud and sync using cc2538 bootloader protocol
+        4. Send 'exit' command via Shell port → CC1352 exits bootloader
 
         Args:
             firmware: Path to firmware file
@@ -773,8 +789,9 @@ class Flasher:
         """
         try:
             ccloader = CCLoader(firmware=firmware, device=device)
-            ccloader.init()
             ccloader.enter_bootloader()
+            time.sleep(0.8)
+            ccloader.init()
             ccloader.sync_device()
             chip_device = ccloader.get_chip_info()
             ccloader.show_chip_details(chip_device)
@@ -790,7 +807,6 @@ class Flasher:
                 try:
                     from .fw_metadata import update_firmware_metadata_after_flash
                     import os
-                    import time
 
                     # Extract firmware name from path
                     firmware_name = os.path.basename(firmware)


### PR DESCRIPTION
## Summary
This fixes an intermittent CatSniffer v3 flashing failure when switching the CC1352 between `ti_sniffer` and `sniffle` firmware.

The failure was not just user timing: the bootloader handoff sequence could leave the RP2040 bridge in the wrong state or attempt the CC1352 sync before the mode switch had fully settled.

## Problem
Flashing could fail with errors like:

```text
Timeout waiting for ACK/NACK after 'Synch (0x55 0x55)'
```

or:

```text
Can't connect to target. Ensure boot loader is started. (no answer on synch sequence)
```

## Root cause
A more reliable sequence on CatSniffer v3 was:

1. send `exit` on Cat-Shell
2. wait briefly
3. send `boot`
4. wait briefly
5. open bridge at `500000`
6. sync bootloader
7. flash firmware

The important differences were:
- forcing a known-good passthrough state before requesting CC1352 ROM bootloader mode
- waiting briefly before opening/syncing the bridge
- dropping the shell connection before bridge sync

## What this changes
In `catnip/modules/flasher.py`:
- `CCLoader.enter_bootloader()` now:
  - flushes shell buffers
  - best-effort calls `exit_bootloader()` first
  - pauses briefly
  - sends `boot`
  - pauses briefly
  - disconnects shell before bridge sync
- `Flasher.flash_firmware()` now:
  - calls `enter_bootloader()` before `init()`
  - waits briefly
  - then opens/syncs the bridge at bootloader baud

## Validation
Validated locally on CatSniffer v3 by successfully running both:

```text
catnip flash ti_sniffer -d 1
catnip flash sniffle -d 1
```

Observed success markers included:
- `Chip ID: 0xF000`
- `Write done`
- `Verified match:`
- `Firmware metadata updated successfully`
- `Device restart complete. Firmware is ready to use!`

## Notes
This PR is intentionally scoped to the flasher/root-cause fix only.
Other local fixes for Wireshark pathing, PCAP header timing, and shell completion were kept separate and can be proposed independently.
