### PR TITLE
ci: skip no-commit-to-branch in the pre-commit workflow

### DIFF
--- a/.github/workflows/.pre-commit.yml
+++ b/.github/workflows/.pre-commit.yml
@@ -24,3 +24,7 @@ jobs:
         python-version: 3.x
     - name: Run pre-commit
       uses: pre-commit/action@v3.0.1
+      env:
+        # no-commit-to-branch is a local guard against committing on main;
+        # in CI the checkout of main itself would always fail it.
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
The hook rejects the branch name, so the workflow fails on every push to main (including merge commits). It stays active for local commits.

https://claude.ai/code/session_01UiMvmFmH6x4DAozxH7RHh5