### PR TITLE
ci: run pre-commit on a detached checkout

### DIFF
--- a/.github/workflows/.pre-commit.yml
+++ b/.github/workflows/.pre-commit.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
     - name: Set up repository
       uses: actions/checkout@v4
+      with:
+        # Check out the commit itself (detached HEAD) so the run is identical
+        # for pushes and pull requests and no hook has to be skipped: the
+        # no-commit-to-branch guard evaluates the checked-out branch name,
+        # and on a push to main the default checkout would be main itself.
+        ref: ${{ github.sha }}
     - name: Set up python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
Checks out the pushed commit by SHA (detached HEAD) so the pre-commit workflow behaves the same for pushes and pull requests. All hooks keep running, including no-commit-to-branch, which failed on pushes to main only because the default checkout attaches the main branch.

https://claude.ai/code/session_01UiMvmFmH6x4DAozxH7RHh5